### PR TITLE
fix cleanup.sh

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -11,7 +11,7 @@ cp sns-test.yml.orig sns-test.yml
 
 rm -rf .dfx candid/assets.did candid/nns-* candid/sns_* \
 *.wasm *.wasm.gz \
-nns-dapp/.dfx/* nns-dapp/canister_ids.json nns-dapp/*.wasm nns-dapp/*.wasm.gz \
+nns-dapp/out nns-dapp/.dfx/* nns-dapp/canister_ids.json nns-dapp/*.wasm nns-dapp/*.wasm.gz \
 internet-identity/.dfx msg.json sns_canister_ids.json
 
 # Remove developer test identities


### PR DESCRIPTION
The documentation is not updated in this PR since the script `cleanup.sh` is not relevant if bootstrapping the environment according to the current instructions.