### PR TITLE
preserve existing dfx identities

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -14,14 +14,6 @@ rm -rf .dfx candid/assets.did candid/nns-* candid/sns_* \
 nns-dapp/out nns-dapp/.dfx/* nns-dapp/canister_ids.json nns-dapp/*.wasm nns-dapp/*.wasm.gz \
 internet-identity/.dfx msg.json sns_canister_ids.json
 
-# Remove developer test identities
-rm -rf "$HOME"/.config/dfx/identity/dev-ident-1/
-rm -rf "$HOME"/.config/dfx/identity/dev-ident-2/
-rm -rf "$HOME"/.config/dfx/identity/dev-ident-3/
-
-rm -rf "$HOME"/.config/dfx/identity/nns-cf-neuron*
-rm -rf "$HOME"/.config/dfx/identity/participant*
-
 # Remove Wallets
 rm -rf ~/.local/share/dfx/network/${NETWORK}/wallets.json
 rm -rf ~/Library/Application\ Support/org.dfinity.dfx/network/${NETWORK}/wallets.json

--- a/constants.sh
+++ b/constants.sh
@@ -61,9 +61,9 @@ esac
 # If DFX is already installed we want to ensure our constants are set correctly
 if which dfx >/dev/null; then
     # We need these identities
-    dfx identity import --force --storage-mode=plaintext dev-ident-1 "$REPO_ROOT/test-identities/dev-ident-1.pem" 2> /dev/null
-    dfx identity import --force --storage-mode=plaintext dev-ident-2 "$REPO_ROOT/test-identities/dev-ident-2.pem" 2> /dev/null
-    dfx identity import --force --storage-mode=plaintext dev-ident-3 "$REPO_ROOT/test-identities/dev-ident-3.pem" 2> /dev/null
+    dfx identity import --storage-mode=plaintext dev-ident-1 "$REPO_ROOT/test-identities/dev-ident-1.pem" 2> /dev/null || true
+    dfx identity import --storage-mode=plaintext dev-ident-2 "$REPO_ROOT/test-identities/dev-ident-2.pem" 2> /dev/null || true
+    dfx identity import --storage-mode=plaintext dev-ident-3 "$REPO_ROOT/test-identities/dev-ident-3.pem" 2> /dev/null || true
 
     # Always change to the configured $DFX_IDENTITY if it's pinned in settings.sh.  Otherwise, fall back to dev-ident-1
     export DFX_IDENTITY=${DFX_IDENTITY:-dev-ident-1}

--- a/participate_sns_sale.sh
+++ b/participate_sns_sale.sh
@@ -18,8 +18,8 @@ do
   dfx identity new --storage-mode=plaintext "${NEW_DFX_IDENTITY}" || true
   dfx identity use "${NEW_DFX_IDENTITY}"
   export ACCOUNT_ID="$(dfx ledger --network ${NETWORK} account-id)"
-  dfx identity import --force --storage-mode=plaintext icp-ident "$REPO_ROOT/test-identities/icp-ident.pem" 2> /dev/null
-  dfx identity use icp-ident
+  dfx identity import --force --storage-mode=plaintext icp-ident-RqOPnjj5ERjAEnwlvfKw "$REPO_ROOT/test-identities/icp-ident.pem" 2> /dev/null
+  dfx identity use icp-ident-RqOPnjj5ERjAEnwlvfKw
   dfx ledger transfer --network "${NETWORK}" --memo 0 --icp "$((2 * ${ICP_PER_PARTICIPANT}))" "${ACCOUNT_ID}" || exit 1;
   dfx identity use "${NEW_DFX_IDENTITY}"
   while [ "$(dfx ledger --network "${NETWORK}" balance)" == "0.00000000 ICP" ]


### PR DESCRIPTION
...also replacing `icp-ident` by `icp-ident-RqOPnjj5ERjAEnwlvfKw` since we need to force it with a particular PEM file and the new identity name with a pseudorandom substring is unlikely to exist on a user's machine