### PR TITLE
bump dfx to 0.14.1

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,7 +9,7 @@ Its default contents are:
 #!/bin/bash
 
 # put your dfx identity here
-export DFX_IDENTITY="default"
+export DX_IDENT="default"
 
 # if you don't export CANISTER_TEST or set its value to "_test",
 # then the test flag is set for NNS and SNS governance canisters;
@@ -35,7 +35,7 @@ export IC_COMMIT="cac353c15ad1e8713607ebc3c56f9e2afd94650a"
 # the asset canister version is specified by a DFX commit
 # you can take an arbitrary DFX commit to master:
 # https://github.com/dfinity/sdk/commits/master
-export DFX_COMMIT="266c913f71344f6fa3320287965120e56288c86c"
+export DX_COMMIT="266c913f71344f6fa3320287965120e56288c86c"
 
 export TESTNET="local"
 ```

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ The `sns-testing` solution is based on Docker; however, there are subtle issues 
    ```
 4. Start a local replica (this will keep running in the current console; press ⌘+C to stop):
    ```bash
-   DFX_NET_JSON="${HOME}/.config/dfx/networks.json"
-   mkdir -p "$(dirname "${DFX_NET_JSON}")"
-   cp "$DFX_NET_JSON" "${DFX_NET_JSON}.tmp" 2>/dev/null  # save original config if present
+   DX_NET_JSON="${HOME}/.config/dfx/networks.json"
+   mkdir -p "$(dirname "${DX_NET_JSON}")"
+   cp "$DX_NET_JSON" "${DX_NET_JSON}.tmp" 2>/dev/null  # save original config if present
    echo '{
       "local": {
          "bind": "0.0.0.0:8080",
@@ -61,9 +61,9 @@ The `sns-testing` solution is based on Docker; however, there are subtle issues 
             "subnet_type": "system"
          }
       }
-   }' > "${DFX_NET_JSON}"
+   }' > "${DX_NET_JSON}"
    ./bin/dfx start --clean; \
-   mv "${DFX_NET_JSON}.tmp" "$DFX_NET_JSON" 2>/dev/null  # restore original config if it was present
+   mv "${DX_NET_JSON}.tmp" "$DX_NET_JSON" 2>/dev/null  # restore original config if it was present
    ```
 
    This should print the dashboard URL, e.g.:

--- a/add_hot_key.sh
+++ b/add_hot_key.sh
@@ -8,7 +8,7 @@ export HOTKEY_IDENTITY="${1:-dev-ident-2}"  && shift # consume the argument
 
 . ./constants.sh normal
 
-export CURRENT_DFX_IDENT=$(dfx identity whoami)
+export CURRENT_DX_IDENT=$(dfx identity whoami)
 
 dfx identity use "${OWNER_IDENTITY}"
 OWNER_PRINCIPAL=$(dfx identity get-principal)
@@ -31,4 +31,4 @@ quill sns \
 quill --insecure-local-dev-mode send --yes msg.json
 
 
-dfx identity use "${CURRENT_DFX_IDENT}"
+dfx identity use "${CURRENT_DX_IDENT}"

--- a/add_permission_assets.sh
+++ b/add_permission_assets.sh
@@ -8,7 +8,7 @@ export PERMISSION=${2:-Commit}
 
 . ./constants.sh normal
 
-export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
+export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
 
 export CID="$(dfx canister --network "${NETWORK}" id assets)"
 

--- a/constants.sh
+++ b/constants.sh
@@ -24,7 +24,7 @@ if [[ -f "$SETTINGS_FILE" ]]; then
 fi
 
 if [[ ! -z "${2:-}" ]]; then
-    DFX_IDENTITY="${2}"
+    DX_IDENT="${2}"
 fi
 
 if [[ -z "$TESTNET" ]]; then
@@ -65,13 +65,13 @@ if which dfx >/dev/null; then
     dfx identity import --storage-mode=plaintext dev-ident-2 "$REPO_ROOT/test-identities/dev-ident-2.pem" 2> /dev/null || true
     dfx identity import --storage-mode=plaintext dev-ident-3 "$REPO_ROOT/test-identities/dev-ident-3.pem" 2> /dev/null || true
 
-    # Always change to the configured $DFX_IDENTITY if it's pinned in settings.sh.  Otherwise, fall back to dev-ident-1
-    export DFX_IDENTITY=${DFX_IDENTITY:-dev-ident-1}
-    dfx identity use "$DFX_IDENTITY"
+    # Always change to the configured $DX_IDENT if it's pinned in settings.sh.  Otherwise, fall back to dev-ident-1
+    export DX_IDENT=${DX_IDENT:-dev-ident-1}
+    dfx identity use "$DX_IDENT"
 
-    export DFX_PRINCIPAL="$(dfx identity get-principal)"
-    export DFX_VERSION="$(dfx --version | sed "s/^dfx //")"
-    export PEM_FILE="$(readlink -f ~/.config/dfx/identity/${DFX_IDENTITY}/identity.pem)"
+    export DX_PRINCIPAL="$(dfx identity get-principal)"
+    export DX_VERSION="$(dfx --version | sed "s/^dfx //")"
+    export PEM_FILE="$(readlink -f ~/.config/dfx/identity/${DX_IDENT}/identity.pem)"
 fi
 
 export CANISTER_TEST="${CANISTER_TEST:-_test}"
@@ -81,7 +81,7 @@ if [[ -z "${DFX_IC_COMMIT:-}" ]]; then
 fi
 
 export NETWORK=$([[ "$TESTNET" == "local" ]] && echo "local" || echo "https://${TESTNET}")
-export DFX_NETWORK=$([[ "$TESTNET" == "local" ]] && echo "local" || echo "https___${TESTNET//./_}")
+export DX_NETWORK=$([[ "$TESTNET" == "local" ]] && echo "local" || echo "https___${TESTNET//./_}")
 export PROTOCOL=$([[ "$TESTNET" == "local" ]] && echo "http" || echo "https")
 
 if [[ "${MODE}" == "install" ]]; then

--- a/deploy_assets.sh
+++ b/deploy_assets.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 . ./constants.sh normal
 
-curl -L "https://github.com/dfinity/sdk/raw/${DFX_COMMIT}/src/distributed/assetstorage.wasm.gz" -o assets.wasm.gz
-curl -L "https://raw.githubusercontent.com/dfinity/sdk/${DFX_COMMIT}/src/distributed/assetstorage.did" -o candid/assets.did
+curl -L "https://github.com/dfinity/sdk/raw/${DX_COMMIT}/src/distributed/assetstorage.wasm.gz" -o assets.wasm.gz
+curl -L "https://raw.githubusercontent.com/dfinity/sdk/${DX_COMMIT}/src/distributed/assetstorage.did" -o candid/assets.did
 
 dfx --provisional-create-canister-effective-canister-id jrlun-jiaaa-aaaab-aaaaa-cai deploy assets --network "${NETWORK}" --no-wallet

--- a/deploy_dapp.sh
+++ b/deploy_dapp.sh
@@ -14,7 +14,7 @@ dfx --provisional-create-canister-effective-canister-id jrlun-jiaaa-aaaab-aaaaa-
 if [[ -z "${WASM}" ]]
 then
   dfx build --network "${NETWORK}" "${NAME}"
-  export WASM=".dfx/${DFX_NETWORK}/canisters/${NAME}/${NAME}.wasm"
+  export WASM=".dfx/${DX_NETWORK}/canisters/${NAME}/${NAME}.wasm"
 fi
 
 dfx canister install "${NAME}" --network "${NETWORK}" --argument "${ARG}" --argument-type idl --wasm "${WASM}"

--- a/deploy_sns.sh
+++ b/deploy_sns.sh
@@ -7,9 +7,9 @@ export CONFIG="${1:-sns-test.yml}" && shift # consume the argument
 
 . ./constants.sh normal
 
-export CURRENT_DFX_IDENT="$(dfx identity whoami)"
+export CURRENT_DX_IDENT="$(dfx identity whoami)"
 
-dfx identity use "${DFX_IDENTITY}"
+dfx identity use "${DX_IDENT}"
 
 . ./setup_wallet.sh
 
@@ -28,9 +28,9 @@ then
   curl -L "https://raw.githubusercontent.com/dfinity/ic/${IC_COMMIT}/rs/nns/governance/canister/governance_test.did" -o ./candid/nns-governance.did
   curl -L "https://raw.githubusercontent.com/dfinity/ic/${IC_COMMIT}/rs/sns/governance/canister/governance_test.did" -o ./candid/sns_governance.did
 fi
-sed "s/aaaaa-aa/${DFX_PRINCIPAL}/" "$CONFIG" > "${CONFIG}.tmp"
+sed "s/aaaaa-aa/${DX_PRINCIPAL}/" "$CONFIG" > "${CONFIG}.tmp"
 mv "${CONFIG}.tmp" "${CONFIG}"
-sns-cli deploy --network "${NETWORK}" --init-config-file "${CONFIG}" --save-to ".dfx/${DFX_NETWORK}/canister_ids.json"
+sns-cli deploy --network "${NETWORK}" --init-config-file "${CONFIG}" --save-to ".dfx/${DX_NETWORK}/canister_ids.json"
 
 # Switch back to the previous identity
-dfx identity use "$CURRENT_DFX_IDENT"
+dfx identity use "$CURRENT_DX_IDENT"

--- a/execute_generic_functions_test.sh
+++ b/execute_generic_functions_test.sh
@@ -7,7 +7,7 @@ export TEXT="${1:-Hoi}"
 
 . ./constants.sh normal
 
-export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
+export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
 
 export BLOB="$(didc encode --format blob "(\"${TEXT}\")")"
 

--- a/generate_initial_neurons.sh
+++ b/generate_initial_neurons.sh
@@ -19,7 +19,7 @@ else
     echo "Using neuron csv ${NEURON_CSV}"
 fi
 
-ORIGINAL_DFX_IDENTITY="$(dfx identity whoami)"
+ORIGINAL_DX_IDENT="$(dfx identity whoami)"
 
 OUTPUT_FILE="${REPO_ROOT}/initial_neurons.csv"
 # clear the file
@@ -65,7 +65,7 @@ done
 echo "449479075714955186;b2ucp-4x6ou-zvxwi-niymn-pvllt-rdxqr-wi4zj-jat5l-ijt2s-vv4f5-4ae;0;31536000000000000;100;D;;false;0;10000000000;false" >> "${OUTPUT_FILE}"
 
 # Restore the original identity
-dfx identity use "${ORIGINAL_DFX_IDENTITY}" 2> /dev/null
+dfx identity use "${ORIGINAL_DX_IDENT}" 2> /dev/null
 
 echo "Generated initial neurons file at ${OUTPUT_FILE}."
 echo "DFX identities have been created for each neuron. View them with ./bin/dfx identity list. (Neuron 1 is ${IDENTITY_PREFIX}1, etc.)."

--- a/get_canister_url.sh
+++ b/get_canister_url.sh
@@ -17,8 +17,8 @@ function get_canister_id() {
 }
 
 
-for DFX_DIR in $(find . -name "*.dfx");do
-      CANISTER_ID=$(get_canister_id "${DFX_DIR}")
+for DX_DIR in $(find . -name "*.dfx");do
+      CANISTER_ID=$(get_canister_id "${DX_DIR}")
       if [[ -n "${CANISTER_ID}" ]]; then
         break
       fi

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ gzip -fd sns.gz
 mv sns sns-cli
 chmod +x sns-cli
 
-curl -L "https://github.com/dfinity/sdk/releases/download/0.13.1/dfx-0.13.1-x86_64-${OS}.tar.gz" -o dfx.tar.gz
+curl -L "https://github.com/dfinity/sdk/releases/download/0.14.1/dfx-0.14.1-x86_64-${OS}.tar.gz" -o dfx.tar.gz
 tar -xzf dfx.tar.gz
 rm dfx.tar.gz
 chmod +x dfx

--- a/list_community_fund_nns_neurons.sh
+++ b/list_community_fund_nns_neurons.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 . ./constants.sh normal
 
-export CURRENT_DFX_IDENT=$(dfx identity whoami)
+export CURRENT_DX_IDENT=$(dfx identity whoami)
 
 for CF_NEURON_IDENTITY in "$HOME"/.config/dfx/identity/nns-cf-neuron*; do
   dfx identity use "${CF_NEURON_IDENTITY}"
@@ -15,5 +15,5 @@ for CF_NEURON_IDENTITY in "$HOME"/.config/dfx/identity/nns-cf-neuron*; do
 done
 
 # Switch back to the previous identity
-dfx identity use "$CURRENT_DFX_IDENT"
+dfx identity use "$CURRENT_DX_IDENT"
 

--- a/list_sns_dev_neurons.sh
+++ b/list_sns_dev_neurons.sh
@@ -5,14 +5,14 @@ set -euo pipefail
 
 . ./constants.sh normal
 
-export CURRENT_DFX_IDENT=$(dfx identity whoami)
+export CURRENT_DX_IDENT=$(dfx identity whoami)
 
 for DEV_IDENT in "$HOME"/.config/dfx/identity/dev-ident-*; do
   PEM_FILE="$(readlink -f "${DEV_IDENT}/identity.pem")"
   dfx identity use "${DEV_IDENT}"
-  export DFX_PRINCIPAL="$(dfx identity get-principal)"
-  export NEURON_IDS="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 0})")"
-  echo "Listing Developer Neurons for Identity $DEV_IDENT, Principal $DFX_PRINCIPAL"
+  export DX_PRINCIPAL="$(dfx identity get-principal)"
+  export NEURON_IDS="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 0})")"
+  echo "Listing Developer Neurons for Identity $DEV_IDENT, Principal $DX_PRINCIPAL"
   echo "$NEURON_IDS"
 
 done
@@ -23,4 +23,4 @@ echo "Listing for $CANISTER_DEV_NEURON"
 dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"$CANISTER_DEV_NEURON\"; limit = 0})"
 
 # Switch back to the previous identity
-dfx identity use "$CURRENT_DFX_IDENT"
+dfx identity use "$CURRENT_DX_IDENT"

--- a/participate_sns_sale.sh
+++ b/participate_sns_sale.sh
@@ -7,26 +7,26 @@ ICP_PER_PARTICIPANT_E8S=$(echo "100000000 * $ICP_PER_PARTICIPANT" | bc)
 
 . ./constants.sh normal
 
-# Reset to the constant's $DFX_IDENTITY before starting the sale
-dfx identity use "$DFX_IDENTITY"
-export CURRENT_DFX_IDENT=$(dfx identity whoami)
+# Reset to the constant's $DX_IDENT before starting the sale
+dfx identity use "$DX_IDENT"
+export CURRENT_DX_IDENT=$(dfx identity whoami)
 
 for (( c=0; c<${NUM_PARTICIPANTS}; c++ ))
 do
   export ID="$(printf "%03d" ${c})"
-  export NEW_DFX_IDENTITY="participant-${ID}"
-  dfx identity new --storage-mode=plaintext "${NEW_DFX_IDENTITY}" || true
-  dfx identity use "${NEW_DFX_IDENTITY}"
+  export NEW_DX_IDENT="participant-${ID}"
+  dfx identity new --storage-mode=plaintext "${NEW_DX_IDENT}" || true
+  dfx identity use "${NEW_DX_IDENT}"
   export ACCOUNT_ID="$(dfx ledger --network ${NETWORK} account-id)"
   dfx identity import --force --storage-mode=plaintext icp-ident-RqOPnjj5ERjAEnwlvfKw "$REPO_ROOT/test-identities/icp-ident.pem" 2> /dev/null
   dfx identity use icp-ident-RqOPnjj5ERjAEnwlvfKw
   dfx ledger transfer --network "${NETWORK}" --memo 0 --icp "$((2 * ${ICP_PER_PARTICIPANT}))" "${ACCOUNT_ID}" || exit 1;
-  dfx identity use "${NEW_DFX_IDENTITY}"
+  dfx identity use "${NEW_DX_IDENT}"
   while [ "$(dfx ledger --network "${NETWORK}" balance)" == "0.00000000 ICP" ]
   do
     sleep 1
   done
-  export PEM_FILE="$(readlink -f ~/.config/dfx/identity/${NEW_DFX_IDENTITY}/identity.pem)"
+  export PEM_FILE="$(readlink -f ~/.config/dfx/identity/${NEW_DX_IDENT}/identity.pem)"
 
   # Get the ticket
   quill sns new-sale-ticket --amount-icp-e8s "${ICP_PER_PARTICIPANT_E8S}" --canister-ids-file ./sns_canister_ids.json --pem-file "${PEM_FILE}" > msg.json
@@ -48,4 +48,4 @@ do
 
 done
 
-dfx identity use "${DFX_IDENTITY}"
+dfx identity use "${DX_IDENT}"

--- a/participate_sns_sale_no_ticket.sh
+++ b/participate_sns_sale_no_ticket.sh
@@ -9,21 +9,21 @@ export ICP_PER_PARTICIPANT="${2:-200}"
 for (( c=0; c<${NUM_PARTICIPANTS}; c++ ))
 do
   export ID="$(printf "%03d" ${c})"
-  export NEW_DFX_IDENTITY="participant-${ID}"
-  dfx identity new --storage-mode=plaintext "${NEW_DFX_IDENTITY}" || true
-  dfx identity use "${NEW_DFX_IDENTITY}"
+  export NEW_DX_IDENT="participant-${ID}"
+  dfx identity new --storage-mode=plaintext "${NEW_DX_IDENT}" || true
+  dfx identity use "${NEW_DX_IDENT}"
   export ACCOUNT_ID="$(dfx ledger --network ${NETWORK} account-id)"
-  dfx identity use "${DFX_IDENTITY}"
+  dfx identity use "${DX_IDENT}"
   dfx ledger transfer --network "${NETWORK}" --memo 0 --icp "$((2 * ${ICP_PER_PARTICIPANT}))" "${ACCOUNT_ID}" || exit 1;
-  dfx identity use "${NEW_DFX_IDENTITY}"
+  dfx identity use "${NEW_DX_IDENT}"
   while [ "$(dfx ledger --network "${NETWORK}" balance)" == "0.00000000 ICP" ]
   do
     sleep 1
   done
-  export PEM_FILE="$(readlink -f ~/.config/dfx/identity/${NEW_DFX_IDENTITY}/identity.pem)"
+  export PEM_FILE="$(readlink -f ~/.config/dfx/identity/${NEW_DX_IDENT}/identity.pem)"
 
   sns-quill --canister-ids-file ./sns_canister_ids.json --pem-file "${PEM_FILE}" swap --memo 0 --amount ${ICP_PER_PARTICIPANT} > msg.json
   sns-quill send --yes msg.json
 done
 
-dfx identity use "${DFX_IDENTITY}"
+dfx identity use "${DX_IDENT}"

--- a/perform_neuron_operation.sh
+++ b/perform_neuron_operation.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 . ./constants.sh normal
 
-export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
+export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
 
 quill sns  \
    --canister-ids-file ./sns_canister_ids.json  \

--- a/register_dapp.sh
+++ b/register_dapp.sh
@@ -10,7 +10,7 @@ export CID=${1:-jrlun-jiaaa-aaaab-aaaaa-cai}
 export SNS_ROOT_ID="$(dfx canister id sns_root --network ${NETWORK})"
 dfx canister --network "${NETWORK}" update-settings --add-controller "${SNS_ROOT_ID}" "${CID}"
 
-export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
+export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
 
 quill sns   \
    --canister-ids-file ./sns_canister_ids.json  \

--- a/register_generic_functions_test.sh
+++ b/register_generic_functions_test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 . ./constants.sh normal
 
-export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
+export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
 
 export CID="$(dfx canister --network "${NETWORK}" id test)"
 quill sns  \

--- a/register_permission_assets.sh
+++ b/register_permission_assets.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 . ./constants.sh normal
 
-export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
+export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
 
 export CID="$(dfx canister --network "${NETWORK}" id assets)"
 

--- a/restore_permission_assets.sh
+++ b/restore_permission_assets.sh
@@ -8,4 +8,4 @@ set -euo pipefail
 SNS_GOVERNANCE_ID="$(dfx canister --network "${NETWORK}" id sns_governance)"
 dfx canister --network "${NETWORK}" call assets revoke_permission "(record {of_principal = principal\"${SNS_GOVERNANCE_ID}\"; permission = variant { ManagePermissions }})"
 
-dfx canister --network "${NETWORK}" call assets grant_permission "(record {to_principal = principal\"${DFX_PRINCIPAL}\"; permission = variant { ManagePermissions }})"
+dfx canister --network "${NETWORK}" call assets grant_permission "(record {to_principal = principal\"${DX_PRINCIPAL}\"; permission = variant { ManagePermissions }})"

--- a/revoke_permission_assets.sh
+++ b/revoke_permission_assets.sh
@@ -8,7 +8,7 @@ export PERMISSION=${2:-Commit}
 
 . ./constants.sh normal
 
-export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
+export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
 
 export CID="$(dfx canister --network "${NETWORK}" id assets)"
 

--- a/send_icp.sh
+++ b/send_icp.sh
@@ -8,5 +8,5 @@ export ACCOUNT="${2}"
 
 . ./constants.sh normal
 
-dfx identity use "${DFX_IDENTITY}"
+dfx identity use "${DX_IDENT}"
 dfx ledger transfer --network "${NETWORK}" --memo 0 --icp "${ICP}" "${ACCOUNT}"

--- a/settings.sh
+++ b/settings.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # put your dfx identity here
-export DFX_IDENTITY="default"
+export DX_IDENT="default"
 
 # if you don't export CANISTER_TEST or set its value to "_test",
 # then the test flag is set for NNS and SNS governance canisters;
@@ -27,6 +27,6 @@ export IC_COMMIT="f0256969bfea4d721060776790ebc87337a82d29"
 # the asset canister version is specified by a DFX commit
 # you can take an arbitrary DFX commit to master:
 # https://github.com/dfinity/sdk/commits/master
-export DFX_COMMIT="266c913f71344f6fa3320287965120e56288c86c"
+export DX_COMMIT="266c913f71344f6fa3320287965120e56288c86c"
 
 export TESTNET="local"

--- a/setup.sh
+++ b/setup.sh
@@ -36,7 +36,7 @@ fi
 
 set -uo pipefail
 
-${DFX} nns import --network-mapping "${DFX_NETWORK}=mainnet"
+${DFX} nns import --network-mapping "${DX_NETWORK}=mainnet"
 if [ "${CANISTER_TEST}" == "_test" ]
 then
   curl -L "https://raw.githubusercontent.com/dfinity/ic/${IC_COMMIT}/rs/nns/governance/canister/governance_test.did" -o ./candid/nns-governance.did
@@ -47,7 +47,7 @@ cd internet-identity || exit
 
 if [ "${TESTNET}" == "local" ]
 then
-  ${DFX} canister create internet_identity --no-wallet
+  ${DFX} canister create internet_identity --no-wallet --specified-id qhbym-qaaaa-aaaaa-aaafq-cai
 fi
 if [ ! -z "${II_RELEASE:-}" ]
 then
@@ -61,9 +61,19 @@ then
   ${DFX} canister create internet_identity --network "${NETWORK}" --no-wallet
 fi
 
-${DFX} canister create nns-dapp --network "${NETWORK}" --no-wallet
+if [ "${TESTNET}" == "local" ]
+then
+  ${DFX} canister create nns-dapp --network "${NETWORK}" --no-wallet --specified-id qsgjb-riaaa-aaaaa-aaaga-cai
+else
+  ${DFX} canister create nns-dapp --network "${NETWORK}" --no-wallet
+fi
 
-${DFX} --provisional-create-canister-effective-canister-id 5v3p4-iyaaa-aaaaa-qaaaa-cai canister create sns_aggregator --network "${NETWORK}" --no-wallet
+if [ "${TESTNET}" == "local" ]
+then
+  ${DFX} canister create sns_aggregator --network "${NETWORK}" --no-wallet --specified-id qvhpv-4qaaa-aaaaa-aaagq-cai
+else
+  ${DFX} --provisional-create-canister-effective-canister-id 5v3p4-iyaaa-aaaaa-qaaaa-cai canister create sns_aggregator --network "${NETWORK}" --no-wallet
+fi
 
 if [ ! -z "${NNS_DAPP_RELEASE:-}" ]
 then

--- a/setup_community_fund.sh
+++ b/setup_community_fund.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 . ./constants.sh normal
 
-export CURRENT_DFX_IDENT=$(dfx identity whoami)
+export CURRENT_DX_IDENT=$(dfx identity whoami)
 
 for CF_NEURON_IDENTITY in "$HOME"/.config/dfx/identity/nns-cf-neuron*; do
   PEM_FILE="$(readlink -f "${CF_NEURON_IDENTITY}/identity.pem")"
@@ -20,4 +20,4 @@ for CF_NEURON_IDENTITY in "$HOME"/.config/dfx/identity/nns-cf-neuron*; do
 done
 
 # Switch back to the previous identity
-dfx identity use "$CURRENT_DFX_IDENT"
+dfx identity use "$CURRENT_DX_IDENT"

--- a/setup_locally.sh
+++ b/setup_locally.sh
@@ -22,6 +22,6 @@ then
   curl -L "https://raw.githubusercontent.com/dfinity/ic/${IC_COMMIT}/rs/sns/governance/canister/governance_test.did" -o ./candid/sns_governance.did
 fi
 
-ic-nns-init --initialize-ledger-with-test-accounts-for-principals "${DFX_PRINCIPAL}" --initialize-ledger-with-test-accounts 5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087 --initialize-ledger-with-test-accounts 2b8fbde99de881f695f279d2a892b1137bfe81a42d7694e064b1be58701e1138 --url "${NETWORK_URL}" --initial-neurons initial_neurons.csv
+ic-nns-init --initialize-ledger-with-test-accounts-for-principals "${DX_PRINCIPAL}" --initialize-ledger-with-test-accounts 5b315d2f6702cb3a27d826161797d7b2c2e131cd312aece51d4d5574d1247087 --initialize-ledger-with-test-accounts 2b8fbde99de881f695f279d2a892b1137bfe81a42d7694e064b1be58701e1138 --url "${NETWORK_URL}" --initial-neurons initial_neurons.csv --pass-specified-id
 
 ./setup.sh

--- a/setup_wallet.sh
+++ b/setup_wallet.sh
@@ -3,7 +3,7 @@
 
 . ./constants.sh normal
 
-DFX_IDENTITY="${1:-dev-ident-1}"
+DX_IDENT="${1:-dev-ident-1}"
 
-dfx identity use $DFX_IDENTITY || { echo "Couldn't load dev identity to create the dev wallet. Exiting..."; exit 1; }
+dfx identity use $DX_IDENT || { echo "Couldn't load dev identity to create the dev wallet. Exiting..."; exit 1; }
 export WALLET="$(dfx --provisional-create-canister-effective-canister-id jrlun-jiaaa-aaaab-aaaaa-cai identity --network "${NETWORK}" get-wallet)"

--- a/transfer_sns_treasury_funds.sh
+++ b/transfer_sns_treasury_funds.sh
@@ -4,11 +4,11 @@
 set -euo pipefail
 
 export AMOUNT_E8s="${1:-1000000000}" # 1 Token
-export TO_PRINCIPAL="${2:-$DFX_PRINCIPAL}"
+export TO_PRINCIPAL="${2:-$DX_PRINCIPAL}"
 
 . ./constants.sh normal
 
-export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
+export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
 
 quill sns  \
    --canister-ids-file ./sns_canister_ids.json  \

--- a/upgrade_dapp.sh
+++ b/upgrade_dapp.sh
@@ -9,12 +9,12 @@ export ARG="${3:-()}"
 
 . ./constants.sh normal
 
-export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
+export DEVELOPER_NEURON_ID="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs didc encode | tail -c +21)"
 
 if [[ -z "${WASM}" ]]
 then
   dfx build --network "${NETWORK}" "${NAME}"
-  export WASM=".dfx/${DFX_NETWORK}/canisters/${NAME}/${NAME}.wasm"
+  export WASM=".dfx/${DX_NETWORK}/canisters/${NAME}/${NAME}.wasm"
 fi
 
 export CID="$(dfx canister --network "${NETWORK}" id "${NAME}")"

--- a/vote_on_sns_proposal.sh
+++ b/vote_on_sns_proposal.sh
@@ -12,11 +12,11 @@ export VOTE="${3:-y}"
 for (( c=0; c<${NUM_PARTICIPANTS}; c++ ))
 do
   export ID="$(printf "%03d" ${c})"
-  export NEW_DFX_IDENTITY="participant-${ID}"
-  export PEM_FILE="$(readlink -f ~/.config/dfx/identity/${NEW_DFX_IDENTITY}/identity.pem)"
-  dfx identity use "${NEW_DFX_IDENTITY}"
-  export DFX_PRINCIPAL="$(dfx identity get-principal)"
-  export NEURON_IDS="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 0})" | grep "^          id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs -L1 didc encode | sed 's/^.\{20\}//')"
+  export NEW_DX_IDENT="participant-${ID}"
+  export PEM_FILE="$(readlink -f ~/.config/dfx/identity/${NEW_DX_IDENT}/identity.pem)"
+  dfx identity use "${NEW_DX_IDENT}"
+  export DX_PRINCIPAL="$(dfx identity get-principal)"
+  export NEURON_IDS="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 0})" | grep "^          id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs -L1 didc encode | sed 's/^.\{20\}//')"
   for NEURON_ID in ${NEURON_IDS}
   do
     quill sns --canister-ids-file ./sns_canister_ids.json --pem-file "${PEM_FILE}" register-vote --proposal-id ${PROPOSAL} --vote ${VOTE} ${NEURON_ID} > msg.json
@@ -24,4 +24,4 @@ do
   done
 done
 
-dfx identity use "${DFX_IDENTITY}"
+dfx identity use "${DX_IDENT}"

--- a/vote_with_developer_neurons.sh
+++ b/vote_with_developer_neurons.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 . ./constants.sh normal
 
-export CURRENT_DFX_IDENT=$(dfx identity whoami)
+export CURRENT_DX_IDENT=$(dfx identity whoami)
 
 export PROPOSAL="${1:-1}"
 export VOTE="${2:-y}"
@@ -13,8 +13,8 @@ export VOTE="${2:-y}"
 for DEV_IDENT in "$HOME"/.config/dfx/identity/dev-ident-*; do
   PEM_FILE="$(readlink -f "${DEV_IDENT}/identity.pem")"
   dfx identity use "${DEV_IDENT}"
-  export DFX_PRINCIPAL="$(dfx identity get-principal)"
-  export NEURON_IDS="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 0})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs -L1 didc encode | sed 's/^.\{20\}//')"
+  export DX_PRINCIPAL="$(dfx identity get-principal)"
+  export NEURON_IDS="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 0})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs -L1 didc encode | sed 's/^.\{20\}//')"
   for NEURON_ID in ${NEURON_IDS}
   do
     quill sns --canister-ids-file ./sns_canister_ids.json --pem-file "${PEM_FILE}" register-vote --proposal-id ${PROPOSAL} --vote ${VOTE} ${NEURON_ID} > "msg_$NEURON_ID.json"
@@ -25,4 +25,4 @@ done
 wait
 
 # Switch back to the previous identity
-dfx identity use "$CURRENT_DFX_IDENT"
+dfx identity use "$CURRENT_DX_IDENT"

--- a/vote_with_single_identity.sh
+++ b/vote_with_single_identity.sh
@@ -9,12 +9,12 @@ export VOTING_IDENTITY="${3:-dev-ident-1}" && shift # consume the argument
 
 . ./constants.sh normal
 
-export CURRENT_DFX_IDENT=$(dfx identity whoami)
+export CURRENT_DX_IDENT=$(dfx identity whoami)
 
 dfx identity use "${VOTING_IDENTITY}"
 PEM_FILE="$(readlink -f "$HOME/.config/dfx/identity/${VOTING_IDENTITY}/identity.pem")"
-export DFX_PRINCIPAL="$(dfx identity get-principal)"
-export NEURON_IDS="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DFX_PRINCIPAL}\"; limit = 0})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs -L1 didc encode | sed 's/^.\{20\}//')"
+export DX_PRINCIPAL="$(dfx identity get-principal)"
+export NEURON_IDS="$(dfx canister --network "${NETWORK}" call sns_governance list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 0})" | grep "^ *id = blob" | sed "s/^ *id = \(.*\);$/'(\1)'/" | xargs -L1 didc encode | sed 's/^.\{20\}//')"
 
 for NEURON_ID in ${NEURON_IDS}
 do
@@ -23,4 +23,4 @@ do
 done
 
 # Switch back to the previous identity
-dfx identity use "$CURRENT_DFX_IDENT"
+dfx identity use "$CURRENT_DX_IDENT"


### PR DESCRIPTION
This PR bumps dfx to 0.14.1 and performs the necessary adjustments:
- use `--pass-specified-ids` with `ic-nns-init`
- use `--specified-id` when creating II, NNS frontend dapp, and SNS aggregator
- rename env variable `DFX_IDENTITY` to `DX_IDENT` (`DFX_IDENTITY` is actually used by dfx since 0.14.0, but we want to use that env variable for our own bookkeeping in the scripts)
- rename substrings `DFX_` in env vars to `DX_` (to prevent "capture" we just experienced with `DFX_IDENTITY` in the future), only keeping `DFX_IC_COMMIT` which is intended to be used by dfx to pin the IC commit used