### PR TITLE
fix setup_wallet.sh

### DIFF
--- a/deploy_sns.sh
+++ b/deploy_sns.sh
@@ -11,7 +11,7 @@ export CURRENT_DX_IDENT="$(dfx identity whoami)"
 
 dfx identity use "${DX_IDENT}"
 
-. ./setup_wallet.sh
+. ./setup_wallet.sh "${DX_IDENT}"
 
 dfx ledger --network "${NETWORK}" fabricate-cycles --canister "${WALLET}" --t 2345
 


### PR DESCRIPTION
Because we source (using `.`) the `setup_wallet.sh` script, we need to provide an explicit argument to it (otherwise, the same argument is used as for the `deploy_sns.sh` script). This is a regression after dropping `shift` in a past PR.