### PR TITLE
add troubleshooting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ created during these steps with your initial SNS developer neurons).
    per participant (specified in the NNS proposal to open the swap).
 
    You can also participate in the swap using the [NNS frontend dapp](http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/) and the "Get ICP" button in the [NNS frontend dapp](http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/) to get a sufficient amount of ICP.
+   Note that it might take a few minutes until you see the SNS swap in the "Launchpad" of the NNS frontend dapp.
+   This is because the SNS aggregator canister takes some time to discover the new SNS and include it in the certified asset pulled by the NNS frontend dapp.
 
    Make sure that the participation satisfies all the constraints
    imposed by the swap parameters from the previous step (e.g., the minimum number

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ After getting familiar with the basic scenario, you may replace the test caniste
 
 The above run-book could be easily automated and integrated into your CI/CD pipeline.
 
+## Troubleshooting
+
+-  If the port 8080 is occupied, then `docker run -p 8080:8080 ...` and `./bin/dfx start --clean` are expected to fail.
+   In that case, you should run `docker ps` (if you have Docker installed on your system) and `lsof -i :8080`
+   to determine the service listening on the port 8080 and then close the service.
+
 ## SNS lifecycle
 
 <a name="lifecycle"></a>
@@ -254,21 +260,29 @@ created during these steps with your initial SNS developer neurons).
    ``` 
    to participate in the swap providing the number of
    participants and the number of ICP that each participant contributes as arguments.
-   You can also participate in the swap using the [NNS frontend dapp](http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/).
-   You can use the "Get ICP" button in the [NNS frontend dapp](http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/)
-   or run the script 
-   ```bash
-   ./send_icp.sh <icp> <account>  # from Bash
-   ``` 
-   to send a certain amount of ICP to your ledger account so you are able
-   to participate in the swap. Make sure that the participation satisfies all the constraints
+   You can run the script `./participate_sns_swap.sh` multiple times as long as
+   the sum of provided `<icp-per-participant>` does not exceed the maximum amount of ICP
+   per participant (specified in the NNS proposal to open the swap).
+
+   You can also participate in the swap using the [NNS frontend dapp](http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/) and the "Get ICP" button in the [NNS frontend dapp](http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/) to get a sufficient amount of ICP.
+
+   Make sure that the participation satisfies all the constraints
    imposed by the swap parameters from the previous step (e.g., the minimum number
-   of swap participants and the total amount of ICP raised).
+   of swap participants and the total amount of ICP raised). For example,
+   to make the swap completed right after running the script `./participate_sns_swap.sh`,
+   you can set `<icp-per-participant>` as `<max-participant-icp-e8s> / 1e8`
+   and `<num-participants>` as `(<max-icp-e8s> / <max-participant-icp-e8s>) + 1`,
+   where `<max-participant-icp-e8s>` and `<max-icp-e8s>` are fixed in the NNS proposal
+   to open the swap.
 7. Once the swap is completed, run the script
    ```bash
    ./finalize_sns_swap.sh  # from Bash
    ``` 
    to distribute the SNS neurons to the swap participants.
+
+   If the swap is not completed, e.g., because the NNS proposal to open the swap failed
+   or the participation is insufficient (too few participants, minimum amount of ICP not reached),
+   then the finalization is expected to fail.
 
 8. Upgrade your dapp again by submitting an SNS proposal that can be voted on using the SNS developer neuron. This however might not be enough to execute the upgrade, so you also need to vote on this proposal using your participants' neurons (this will be covered in the next step).
 

--- a/generate_initial_neurons.sh
+++ b/generate_initial_neurons.sh
@@ -42,7 +42,7 @@ readarray -t LINES < "${NEURON_CSV}"
 generate_identity_for_index () {
     local IDENTITY_INDEX=$1
     local IDENTITY_NAME="${IDENTITY_PREFIX}${IDENTITY_INDEX}"
-    dfx identity new --storage-mode=plaintext "${IDENTITY_NAME}"
+    dfx identity new --storage-mode=plaintext "${IDENTITY_NAME}" 2>/dev/null || true
     dfx identity use "${IDENTITY_NAME}" 2> /dev/null
     local PRINCIPAL="$(dfx identity get-principal)"
     echo "${PRINCIPAL}"

--- a/participate_sns_swap.sh
+++ b/participate_sns_swap.sh
@@ -15,7 +15,7 @@ for (( c=0; c<${NUM_PARTICIPANTS}; c++ ))
 do
   export ID="$(printf "%03d" ${c})"
   export NEW_DX_IDENT="participant-${ID}"
-  dfx identity new --storage-mode=plaintext "${NEW_DX_IDENT}" || true
+  dfx identity new --storage-mode=plaintext "${NEW_DX_IDENT}" 2>/dev/null || true
   dfx identity use "${NEW_DX_IDENT}"
   export ACCOUNT_ID="$(dfx ledger --network ${NETWORK} account-id)"
   dfx identity import --force --storage-mode=plaintext icp-ident-RqOPnjj5ERjAEnwlvfKw "$REPO_ROOT/test-identities/icp-ident.pem" 2> /dev/null

--- a/participate_sns_swap_no_ticket.sh
+++ b/participate_sns_swap_no_ticket.sh
@@ -10,7 +10,7 @@ for (( c=0; c<${NUM_PARTICIPANTS}; c++ ))
 do
   export ID="$(printf "%03d" ${c})"
   export NEW_DX_IDENT="participant-${ID}"
-  dfx identity new --storage-mode=plaintext "${NEW_DX_IDENT}" || true
+  dfx identity new --storage-mode=plaintext "${NEW_DX_IDENT}" 2>/dev/null || true
   dfx identity use "${NEW_DX_IDENT}"
   export ACCOUNT_ID="$(dfx ledger --network ${NETWORK} account-id)"
   dfx identity use "${DX_IDENT}"


### PR DESCRIPTION
This MR adds some more (troubleshooting) instructions and silences (expected) error lines of the form `Error: Identity already exists.` printed by DFX if an identity already exists.