### PR TITLE
replace backticks by single ticks in echo

### DIFF
--- a/generate_initial_neurons.sh
+++ b/generate_initial_neurons.sh
@@ -69,4 +69,4 @@ echo "449479075714955186;b2ucp-4x6ou-zvxwi-niymn-pvllt-rdxqr-wi4zj-jat5l-ijt2s-v
 dfx identity use "${ORIGINAL_DX_IDENT}" 2> /dev/null
 
 echo "Generated initial neurons file at ${OUTPUT_FILE}."
-echo "DFX identities have been created for each neuron. View them with `dfx identity list`. (Neuron 1 is ${IDENTITY_PREFIX}1, etc.)."
+echo "DFX identities have been created for each neuron. View them with 'dfx identity list'. (Neuron 1 is ${IDENTITY_PREFIX}1, etc.)."


### PR DESCRIPTION
Using backticks makes the command evaluated in the current shell instead of printing the command.

This is a regression introduced here: 21dcc0f3c4f7ee90a76acae1e5f87a3c801e2684