### PR TITLE
publish Docker image on CI

### DIFF
--- a/.github/workflows/sns_lifecycle.yml
+++ b/.github/workflows/sns_lifecycle.yml
@@ -45,3 +45,30 @@ jobs:
       run: |
         SNS_TESTING_INSTANCE=$(docker ps -q)
         docker kill $SNS_TESTING_INSTANCE
+
+  publish:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: sns_lifecycle
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v4.6.0
+      with:
+        images: ghcr.io/dfinity/sns-testing
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4.1.1
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/sns_lifecycle.yml
+++ b/.github/workflows/sns_lifecycle.yml
@@ -5,6 +5,8 @@ on:
      branches: [ main ]
   pull_request:
 
+permissions: write-all
+
 jobs:
   sns_lifecycle:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ After getting familiar with the basic scenario, you may replace the test caniste
 2. Start a local replica instance:
     ```bash
    SNS_TESTING_INSTANCE=$(
-       docker run -p 8080:8080 -v "`pwd`":/dapp -d martin2718/sns-testing:latest dfx start --clean
+       docker run -p 8080:8080 -v "`pwd`":/dapp -d ghcr.io/dfinity/sns-testing:main dfx start --clean
    )
    while ! docker logs $SNS_TESTING_INSTANCE 2>&1 | grep -m 1 'Dashboard:'
    do


### PR DESCRIPTION
This PR makes the Docker image for sns-testing published to Github registry automatically on CI.

Note. Publishing the Docker image from commits to the main branch has been tested on a fork of sns-testing.