### PR TITLE
drop Finalize SNS swap from the basic scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ created during these steps with your initial SNS developer neurons).
    Make sure that the participation satisfies all the constraints
    imposed by the swap parameters from the previous step (e.g., the minimum number
    of swap participants and the total amount of ICP raised). For example,
-   to contribute enough ICP to be able to finalize the swap right away, run:
+   to contribute enough ICP for the swap to complete right away, run:
 
    ```bash
    ./participate_sns_swap.sh 3 10
@@ -287,17 +287,7 @@ created during these steps with your initial SNS developer neurons).
    Note that this will work as described only for the default swap parameters specified in `./open_sns_swap.sh`;
    if you decide to customize these parameters, please adjust `<num-participants>` and `<icp-per-participant>` to your testing scenario.
 
-7. Once the swap is completed, run the script
-   ```bash
-   ./finalize_sns_swap.sh  # from Bash
-   ``` 
-   to distribute the SNS neurons to the swap participants.
-
-   If the swap is not completed, e.g., because the NNS proposal to open the swap failed
-   or the participation is insufficient (too few participants, minimum amount of ICP not reached),
-   then the finalization is expected to fail.
-
-8. Upgrade your dapp again by submitting an SNS proposal that can be voted on using the SNS developer neuron. This however might not be enough to execute the upgrade, so you also need to vote on this proposal using your participants' neurons (this will be covered in the next step).
+7. Upgrade your dapp again by submitting an SNS proposal that can be voted on using the SNS developer neuron. This however might not be enough to execute the upgrade, so you also need to vote on this proposal using your participants' neurons (this will be covered in the next step).
 
     This step requires your dapp repo to have an upgrade script that interacts with the replica via the 8080 port.
 
@@ -312,7 +302,7 @@ created during these steps with your initial SNS developer neurons).
    for further details) to use a new greeting when calling the `greet` method it exposes. If you don't provide `<new_greeting>`, `"Hoi"` will be used by default. 
    The test canister can be thought of as a placeholder for your dapp.
 
-9. After the decentralization swap, your developer neuron might not have
+8. After the decentralization swap, your developer neuron might not have
    a majority of the voting power and thus the SNS proposal to upgrade your dapp canister must be voted
    on. To this end, open the [NNS frontend dapp](http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/) and vote with the individual neurons or run the script:
 

--- a/finalize_sns_swap.sh
+++ b/finalize_sns_swap.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
-
-. ./constants.sh normal
-
-dfx canister --network "${NETWORK}" call sns_swap finalize_swap '(record {})'

--- a/run_basic_scenario.sh
+++ b/run_basic_scenario.sh
@@ -50,14 +50,6 @@ jq -r '.swap_canister_id' -e sns_canister_ids.json
 # wait for the SNS swap to become completed (until heartbeat on SNS swap canister is executed)
 while [ "$(./get_sns_swap_state.sh | sed "s/: float32/: nat64/" | ./bin/idl2json | jq -r '.swap[0].lifecycle')" != "3" ]; do sleep 1; done
 
-# Finalize SNS swap
-
-SWAP="$(./finalize_sns_swap.sh | ./bin/idl2json)"
-# assert that the swap has been successful for the 3 participants from the previous step
-[ "$(echo "${SWAP}" | jq -r '.sweep_icp_result[0].success')" == "3" ] && echo "OK" || exit 1
-[ "$(echo "${SWAP}" | jq -r '.claim_neuron_result[0].success')" == "9" ] && echo "OK" || exit 1
-[ "$(echo "${SWAP}" | jq -r '.sweep_sns_result[0].success')" == "9" ] && echo "OK" || exit 1
-
 # Upgrade test canister
 
 ./upgrade_test_canister.sh Welcome

--- a/settings.sh
+++ b/settings.sh
@@ -26,6 +26,6 @@ export NNS_DAPP_RELEASE="proposal-123301"
 # $ ./gitlab-ci/src/artifacts/newest_sha_with_disk_image.sh origin/master
 # from the IC monorepo: https://github.com/dfinity/ic
 # if you change IC_COMMIT, then you need to rerun `source install.sh`
-export IC_COMMIT="e4a9c0aa4ef24f7ee5bb9d27ce930551a7c5e24d"
+export IC_COMMIT="91cef7a53a5064fe3d41a5f2a0e87b65123af4b0"
 
 export TESTNET="local"


### PR DESCRIPTION
This PR drops the explicit SNS swap finalization step which is possible using the latest SNS canister implementation.