### PR TITLE
bump dfx to 0.14.2 and bind the replica dashboard to a fixed port

### DIFF
--- a/.github/workflows/sns_lifecycle.yml
+++ b/.github/workflows/sns_lifecycle.yml
@@ -36,7 +36,7 @@ jobs:
         docker exec $SNS_TESTING_INSTANCE bash run_basic_scenario.sh
     - name: Internet Computer Replica Dashboard smoke test
       run: |
-        if curl --output /dev/null --silent --head --fail -r 0-0 "http://localhost:8000/_/dashboard"
+        if curl --output /dev/null --silent --fail -r 0-0 "http://localhost:8000/_/dashboard"
         then
             echo "Internet Computer Replica Dashboard is online"
         else

--- a/.github/workflows/sns_lifecycle.yml
+++ b/.github/workflows/sns_lifecycle.yml
@@ -34,6 +34,15 @@ jobs:
       run: |
         SNS_TESTING_INSTANCE=$(docker ps -q)
         docker exec $SNS_TESTING_INSTANCE bash run_basic_scenario.sh
+    - name: Internet Computer Replica Dashboard smoke test
+      run: |
+        if curl --output /dev/null --silent --head --fail -r 0-0 "http://localhost:8000/_/dashboard"
+        then
+            echo "Internet Computer Replica Dashboard is online"
+        else
+            echo "Internet Computer Replica Dashboard is NOT AVAILABLE!"
+            exit 1
+        fi
     - name: NNS frontend dapp smoke test
       run: |
         if curl --output /dev/null --silent --head --fail -r 0-0 "http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/launchpad/"

--- a/.github/workflows/sns_lifecycle.yml
+++ b/.github/workflows/sns_lifecycle.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Start docker image
       run: |
         SNS_TESTING_INSTANCE=$(
-          docker run -p 8080:8080 -v "`pwd`":/dapp -d ghcr.io/dfinity/sns-testing dfx start --clean
+          docker run -p 8000:8000 -p 8080:8080 -v "`pwd`":/dapp -d ghcr.io/dfinity/sns-testing dfx start --clean
         )
         while ! docker logs $SNS_TESTING_INSTANCE 2>&1 | grep -m 1 'Dashboard:'
         do

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN echo '{ \n\
     "bind": "0.0.0.0:8080", \n\
     "type": "ephemeral", \n\
     "replica": { \n\
-      "subnet_type": "system" \n\
+      "subnet_type": "system", \n\
+      "port": 8000 \n\
     } \n\
   } \n\
 }' > /home/sns/.config/dfx/networks.json

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The above run-book could be easily automated and integrated into your CI/CD pipe
 
 -  If either of the ports 8000 or 8080 are occupied, then `docker run -p 8000:8000 -p 8080:8080 ...` and `./bin/dfx start --clean` are expected to fail.
    In that case, you should run `docker ps` (if you have Docker installed on your system) and `lsof -i :8000` or `lsof -i :8080`
-   to determine the service listening on the port 8000 or 8080 and then close the service.
+   to determine the service listening on the port 8000 or 8080, correspondingly, and then close the service.
 
 ## SNS lifecycle
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The above run-book could be easily automated and integrated into your CI/CD pipe
 
 ## Troubleshooting
 
--  If the port 8000 or 8080 is occupied, then `docker run -p 8000:8000 -p 8080:8080 ...` and `./bin/dfx start --clean` are expected to fail.
+-  If either of the ports 8000 or 8080 are occupied, then `docker run -p 8000:8000 -p 8080:8080 ...` and `./bin/dfx start --clean` are expected to fail.
    In that case, you should run `docker ps` (if you have Docker installed on your system) and `lsof -i :8000` or `lsof -i :8080`
    to determine the service listening on the port 8000 or 8080 and then close the service.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ The `sns-testing` solution is based on Docker; however, there are subtle issues 
          "bind": "0.0.0.0:8080",
          "type": "ephemeral",
          "replica": {
-            "subnet_type": "system"
+            "subnet_type": "system",
+            "port": 8000
          }
       }
    }' > "${DX_NET_JSON}"
@@ -79,10 +80,10 @@ The `sns-testing` solution is based on Docker; however, there are subtle issues 
 
    While running these instructions for the first time, you may need to hit the ``Allow'' button to authorize the system to execute the binaries shipped with sns-testing, e.g., `./bin/dfx`.
 
-   This should print the dashboard URL, e.g.:
+   This should print the dashboard URL:
 
     ```
-    Dashboard: http://localhost:35727/_/dashboard
+    Dashboard: http://localhost:8000/_/dashboard
     ```
 
 5. Open another Bash console:
@@ -140,14 +141,12 @@ After getting familiar with the basic scenario, you may replace the test caniste
        sleep 3
    done
     ```
-    This should print the dashboard URL, e.g.:
+    This should print the dashboard URL:
 
     ```
     Awaiting local replica ...
-    Dashboard: http://localhost:35727/_/dashboard
+    Dashboard: http://localhost:8000/_/dashboard
     ```
-
-    Note that the dashboard is currently not accessible from the browser on your host system.
 
 3. Run setup:
     ```bash

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ After getting familiar with the basic scenario, you may replace the test caniste
 2. Start a local replica instance:
     ```bash
    SNS_TESTING_INSTANCE=$(
-       docker run -p 8080:8080 -v "`pwd`":/dapp -d ghcr.io/dfinity/sns-testing:main dfx start --clean
+       docker run -p 8000:8000 -p 8080:8080 -v "`pwd`":/dapp -d ghcr.io/dfinity/sns-testing:main dfx start --clean
    )
    while ! docker logs $SNS_TESTING_INSTANCE 2>&1 | grep -m 1 'Dashboard:'
    do
@@ -182,9 +182,9 @@ The above run-book could be easily automated and integrated into your CI/CD pipe
 
 ## Troubleshooting
 
--  If the port 8080 is occupied, then `docker run -p 8080:8080 ...` and `./bin/dfx start --clean` are expected to fail.
-   In that case, you should run `docker ps` (if you have Docker installed on your system) and `lsof -i :8080`
-   to determine the service listening on the port 8080 and then close the service.
+-  If the port 8000 or 8080 is occupied, then `docker run -p 8000:8000 -p 8080:8080 ...` and `./bin/dfx start --clean` are expected to fail.
+   In that case, you should run `docker ps` (if you have Docker installed on your system) and `lsof -i :8000` or `lsof -i :8080`
+   to determine the service listening on the port 8000 or 8080 and then close the service.
 
 ## SNS lifecycle
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ curl -L "https://download.dfinity.systems/ic/${IC_COMMIT}/openssl-static-binarie
 gzip -fd sns.gz
 chmod +x sns
 
-curl -L "https://github.com/dfinity/sdk/releases/download/0.14.1/dfx-0.14.1-x86_64-${OS}.tar.gz" -o dfx.tar.gz
+curl -L "https://github.com/dfinity/sdk/releases/download/0.14.2/dfx-0.14.2-x86_64-${OS}.tar.gz" -o dfx.tar.gz
 tar -xzf dfx.tar.gz
 rm dfx.tar.gz
 chmod +x dfx


### PR DESCRIPTION
This PR bumps dfx to the latest release (0.14.2) which allows us to bind the replica dashboard to a fixed port and expose this port from the Docker container to the host environment.