### PR TITLE
Fix `generate_identities_for_neurons_fund_neurons.sh` and improve instructions for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The `sns-testing` solution is based on Docker; however, there are subtle issues 
 
 0. Make sure you have Homebrew installed.
    * Instructions: https://brew.sh/
-   * Use Homebrew to install `coreutils` (needed for tools e.g., `sha256sum`), `jq`, and `yq`:
+   * Use Homebrew to install (or upgrade to the latest available versions) `bash`, `coreutils` (needed for tools e.g., `sha256sum`), `jq`, and `yq`:
      ```bash
-     brew install coreutils jq yq
+     brew install bash coreutils jq yq
      ```
 
    You also need rosetta that you can install by running:

--- a/generate_identities_for_neurons_fund_neurons.sh
+++ b/generate_identities_for_neurons_fund_neurons.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -xeuo pipefail
 
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
@@ -51,7 +51,7 @@ do
         # as they are freshly generated (because we need access to their DFX identities to
         # be able to read their data and manipulate them, e.g., adding them to the NF after
         # the NNS is installed).
-        sed -i "$((i+1))s/\(^30[0-9][0-9];\)[-a-z0-9]*;/\1${PRINCIPAL};/" "${NEURON_CSV}"
+        sed -i'' -e "$((i+1))s/\(^30[0-9][0-9];\)[-a-z0-9]*;/\1${PRINCIPAL};/" "${NEURON_CSV}"
         echo "Ensured the existence of Neurons' Fund neuron ID ${neuron_id} with identity principal = ${PRINCIPAL}"
     fi;
 done


### PR DESCRIPTION
This PR addresses an issue due to which some macOS users were hitting errors while trying to follow README instructions on Apple Silicon systems.