### PR TITLE
Document that SNS logo should be a 1:1 circle.

### DIFF
--- a/example_sns_init.yaml
+++ b/example_sns_init.yaml
@@ -82,6 +82,8 @@ Principals: []
 # Path to the SNS Project logo on the local filesystem. The path is relative
 # to the configuration file's location, unless an absolute path is given.
 # Must have less than 341,334 bytes. The only supported format is PNG.
+# Consider that NNS dapp will render the image with a 1:1 aspect ratio and
+# cropped to a circle.
 logo: logo.png
 
 # URL to the dapp controlled by the SNS project.


### PR DESCRIPTION
To avoid extra work for SNS creators after realizing that their logo doesn't look nice in the NNS dapp UI, document in the sns_init_template.yaml how the logo image is displayed in NNS dapp.