### PR TITLE
chore: bump SNS aggregator version and configure it to be fast

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR ${WDIR}
 RUN locale-gen en_US.UTF-8 &&\
     echo "export LANG=en_US.UTF-8 LANGUAGE=en_US.en LC_ALL=en_US.UTF-8" >> /home/sns/.bashrc
 
-ARG RUST_VERSION=1.67.0
+ARG RUST_VERSION=1.77.2
 ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin:$PATH

--- a/settings.sh
+++ b/settings.sh
@@ -25,7 +25,7 @@ export NNS_DAPP_RELEASE="nightly-2023-10-30"
 # you can find NNS proposals upgrading system canisters here:
 # https://dashboard.internetcomputer.org/governance?topic=TOPIC_NETWORK_CANISTER_MANAGEMENT
 # NNS proposals to upgrade NNS frontend dapp are called "Upgrade Nns Canister: 3r4gx-wqaaa-aaaaq-aaaia-cai"
-export SNS_AGGREGATOR_RELEASE="proposal-129614"
+export SNS_AGGREGATOR_RELEASE="proposal-129614-agg"
 
 # only edit IC_COMMIT to a commit to master with disk image obtained via:
 # $ ./gitlab-ci/src/artifacts/newest_sha_with_disk_image.sh origin/master

--- a/settings.sh
+++ b/settings.sh
@@ -22,6 +22,11 @@ export II_RELEASE="release-2023-10-30"
 # NNS proposals to upgrade NNS frontend dapp are called "Upgrade Nns Canister: qoctq-giaaa-aaaaa-aaaea-cai"
 export NNS_DAPP_RELEASE="nightly-2023-10-30"
 
+# you can find NNS proposals upgrading system canisters here:
+# https://dashboard.internetcomputer.org/governance?topic=TOPIC_NETWORK_CANISTER_MANAGEMENT
+# NNS proposals to upgrade NNS frontend dapp are called "Upgrade Nns Canister: 3r4gx-wqaaa-aaaaq-aaaia-cai"
+export SNS_AGGREGATOR_RELEASE="proposal-129614"
+
 # only edit IC_COMMIT to a commit to master with disk image obtained via:
 # $ ./gitlab-ci/src/artifacts/newest_sha_with_disk_image.sh origin/master
 # from the IC monorepo: https://github.com/dfinity/ic

--- a/setup.sh
+++ b/setup.sh
@@ -78,7 +78,7 @@ then
   curl -L "https://github.com/dfinity/nns-dapp/releases/download/${SNS_AGGREGATOR_RELEASE}/sns_aggregator_dev.wasm.gz" -o nns-dapp/out/sns_aggregator.wasm
 fi
 
-${DFX} canister install sns_aggregator --network "${NETWORK}" --wasm nns-dapp/out/sns_aggregator.wasm '(opt record { update_interval_ms = 1000; fast_interval_ms = 100; })'
+${DFX} canister install sns_aggregator --network "${NETWORK}" --wasm nns-dapp/out/sns_aggregator.wasm '(opt record { update_interval_ms = 1000:nat64; fast_interval_ms = 100:nat64; })'
 ${DFX} canister install internet_identity --network "${NETWORK}" --wasm internet-identity/internet_identity_dev.wasm --argument '(null)'
 ${DFX} canister install nns-dapp --network "${NETWORK}" --wasm nns-dapp/out/nns-dapp.wasm --argument '(opt record{
   args = vec {

--- a/setup.sh
+++ b/setup.sh
@@ -78,7 +78,10 @@ then
   curl -L "https://github.com/dfinity/nns-dapp/releases/download/${SNS_AGGREGATOR_RELEASE}/sns_aggregator_dev.wasm.gz" -o nns-dapp/out/sns_aggregator.wasm
 fi
 
+# Install the SNS aggregator and configure it to refresh every second so that the NNS dapp is as up-to-date as possible.
+# This is possible in local testing as we can afford the additional load in local testing.
 ${DFX} canister install sns_aggregator --network "${NETWORK}" --wasm nns-dapp/out/sns_aggregator.wasm --argument '(opt record { update_interval_ms = 1000:nat64; fast_interval_ms = 100:nat64; })'
+
 ${DFX} canister install internet_identity --network "${NETWORK}" --wasm internet-identity/internet_identity_dev.wasm --argument '(null)'
 ${DFX} canister install nns-dapp --network "${NETWORK}" --wasm nns-dapp/out/nns-dapp.wasm --argument '(opt record{
   args = vec {

--- a/setup.sh
+++ b/setup.sh
@@ -78,7 +78,7 @@ then
   curl -L "https://github.com/dfinity/nns-dapp/releases/download/${SNS_AGGREGATOR_RELEASE}/sns_aggregator_dev.wasm.gz" -o nns-dapp/out/sns_aggregator.wasm
 fi
 
-${DFX} canister install sns_aggregator --network "${NETWORK}" --wasm nns-dapp/out/sns_aggregator.wasm '(opt record { update_interval_ms = 1000:nat64; fast_interval_ms = 100:nat64; })'
+${DFX} canister install sns_aggregator --network "${NETWORK}" --wasm nns-dapp/out/sns_aggregator.wasm --argument '(opt record { update_interval_ms = 1000:nat64; fast_interval_ms = 100:nat64; })'
 ${DFX} canister install internet_identity --network "${NETWORK}" --wasm internet-identity/internet_identity_dev.wasm --argument '(null)'
 ${DFX} canister install nns-dapp --network "${NETWORK}" --wasm nns-dapp/out/nns-dapp.wasm --argument '(opt record{
   args = vec {

--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ then
 fi
 curl -L "https://raw.githubusercontent.com/dfinity/internet-identity/${II_RELEASE}/src/internet_identity/internet_identity.did" -o candid/internet_identity.did
 curl -L "https://raw.githubusercontent.com/dfinity/nns-dapp/${NNS_DAPP_RELEASE}/rs/backend/nns-dapp.did" -o candid/nns-dapp.did
-curl -L "https://raw.githubusercontent.com/dfinity/nns-dapp/${NNS_DAPP_RELEASE}/sns_aggregator/sns_aggregator.did" -o ./candid/sns_aggregator.did
+curl -L "https://raw.githubusercontent.com/dfinity/nns-dapp/${SNS_AGGREGATOR_RELEASE}/sns_aggregator/sns_aggregator.did" -o ./candid/sns_aggregator.did
 cat <<< $(jq -r 'del(.canisters."internet_identity".remote)' dfx.json) > dfx.json
 cat <<< $(jq -r 'del(.canisters."nns-dapp".remote)' dfx.json) > dfx.json
 cat <<< $(jq -r 'del(.canisters."sns_aggregator".remote)' dfx.json) > dfx.json
@@ -70,10 +70,15 @@ if [ ! -z "${NNS_DAPP_RELEASE:-}" ]
 then
   mkdir -p nns-dapp/out
   curl -L "https://github.com/dfinity/nns-dapp/releases/download/${NNS_DAPP_RELEASE}/nns-dapp.wasm.gz" -o nns-dapp/out/nns-dapp.wasm
-  curl -L "https://github.com/dfinity/nns-dapp/releases/download/${NNS_DAPP_RELEASE}/sns_aggregator_dev.wasm.gz" -o nns-dapp/out/sns_aggregator.wasm
 fi
 
-${DFX} canister install sns_aggregator --network "${NETWORK}" --wasm nns-dapp/out/sns_aggregator.wasm
+if [ ! -z "${SNS_AGGREGATOR_RELEASE:-}" ]
+then
+  mkdir -p nns-dapp/out
+  curl -L "https://github.com/dfinity/nns-dapp/releases/download/${SNS_AGGREGATOR_RELEASE}/sns_aggregator_dev.wasm.gz" -o nns-dapp/out/sns_aggregator.wasm
+fi
+
+${DFX} canister install sns_aggregator --network "${NETWORK}" --wasm nns-dapp/out/sns_aggregator.wasm '(opt record { update_interval_ms = 1000; fast_interval_ms = 100; })'
 ${DFX} canister install internet_identity --network "${NETWORK}" --wasm internet-identity/internet_identity_dev.wasm --argument '(null)'
 ${DFX} canister install nns-dapp --network "${NETWORK}" --wasm nns-dapp/out/nns-dapp.wasm --argument '(opt record{
   args = vec {


### PR DESCRIPTION
This PR bumps the SNS aggregator version and configures it to be fast. This makes the NNS frontend dapp launchpad update quickly once an NNS proposal to create an SNS is executed.