### PR TITLE
Update example_sns_init.yaml (prepare for new SNS constraints)

### DIFF
--- a/example_sns_init.yaml
+++ b/example_sns_init.yaml
@@ -399,7 +399,7 @@ Swap:
     # The minimum amount of ICP that each participant must contribute
     # to participate. This field is specified as a token. For instance,
     # "1 token".
-    minimum_participant_icp:     10 tokens
+    minimum_participant_icp:    100 tokens
 
     # The maximum amount of ICP that each participant may contribute
     # to participate. This field is specified as a token. For instance,
@@ -432,7 +432,7 @@ Swap:
         # many neurons will be in each participant's neuron basket. Note that
         # the first neuron in each neuron basket will have zero dissolve delay.
         # This value should thus be greater than or equal to `2`.
-        events: 3
+        events: 2
 
         # The interval at which the schedule will be increased per event. The
         # first neuron in the basket will be unlocked with zero dissolve delay.


### PR DESCRIPTION
The new constraint is `(maximum_direct_participation_icp / minimum_participant_icp) * VestingSchedule.events <= 100_000`.

Added in https://github.com/dfinity/ic/commit/4a092ca67dbf0f99a1440d4348275c9a6c33dbfb