### PR TITLE
Upgrade DFX to 0.22.0

### DIFF
--- a/constants.sh
+++ b/constants.sh
@@ -118,16 +118,6 @@ if [[ "${TESTNET}" == "local" ]]; then
   then
     export REGISTRY_PATH="$(readlink -f "${REGISTRY}")"
   fi
-  REGISTRY="${HOME}/Library/Application Support/org.dfinity.dfx/network/local/state/replicated_state/ic_registry_local_store"
-  if [[ -d "${REGISTRY}" ]]
-  then
-    export REGISTRY_PATH="$(readlink -f "${REGISTRY}")"
-  fi
-  REGISTRY="${HOME}/.local/share/dfx/network/local/state/replicated_state/ic_registry_local_store"
-  if [[ -d "${REGISTRY}" ]]
-  then
-    export REGISTRY_PATH="$(readlink -f "${REGISTRY}")"
-  fi
   # Determine the operating system
   OS_TYPE="$(uname)"
   if [[ "$OS_TYPE" == "Darwin" ]]; then
@@ -140,8 +130,13 @@ if [[ "${TESTNET}" == "local" ]]; then
   fi
 
   # Find the ic_registry_local_store directory within the base path
-  REGISTRY_FOUND=$(find "$BASE_PATH" -type d -name ic_registry_local_store 2>/dev/null | head -n 1)
+  REGISTRY_FOUND=$(find "$BASE_PATH" -type d -name ic_registry_local_store 2>/dev/null)
 
+  if [ $(echo "$REGISTRY_FOUND" | wc -l) -gt 1 ]; then
+      echo "Error: Multiple ic_registry_local_store directories found"
+      exit 1
+  fi
+  
   # If the directory is found, set REGISTRY_PATH to its absolute path
   if [[ -d "$REGISTRY_FOUND" ]]; then
     export REGISTRY_PATH="$(readlink -f "$REGISTRY_FOUND")"
@@ -149,7 +144,7 @@ if [[ "${TESTNET}" == "local" ]]; then
 
   if [[ -z "${REGISTRY_PATH}" ]]
   then
-    echo "Local registry not found!"
+    echo "Error: Local registry not found!"
     exit 1
   fi
   export NNS_SUB="$(ic-regedit snapshot "${REGISTRY_PATH}" | jq -r .nns_subnet_id.principal_id.raw | sed "s/(principal-id)//")"

--- a/constants.sh
+++ b/constants.sh
@@ -128,6 +128,25 @@ if [[ "${TESTNET}" == "local" ]]; then
   then
     export REGISTRY_PATH="$(readlink -f "${REGISTRY}")"
   fi
+  # Determine the operating system
+  OS_TYPE="$(uname)"
+  if [[ "$OS_TYPE" == "Darwin" ]]; then
+    BASE_PATH="$HOME/Library/Application Support/org.dfinity.dfx/network/local"
+  elif [[ "$OS_TYPE" == "Linux" ]]; then
+    BASE_PATH="$HOME/.local/share/dfx/network/local"
+  else
+    echo "Unsupported OS type: $OS_TYPE"
+    exit 1
+  fi
+
+  # Find the ic_registry_local_store directory within the base path
+  REGISTRY_FOUND=$(find "$BASE_PATH" -type d -name ic_registry_local_store 2>/dev/null | head -n 1)
+
+  # If the directory is found, set REGISTRY_PATH to its absolute path
+  if [[ -d "$REGISTRY_FOUND" ]]; then
+    export REGISTRY_PATH="$(readlink -f "$REGISTRY_FOUND")"
+  fi
+
   if [[ -z "${REGISTRY_PATH}" ]]
   then
     echo "Local registry not found!"

--- a/settings.sh
+++ b/settings.sh
@@ -35,6 +35,6 @@ export IC_COMMIT="f79476803e097d9fd5f7e67d45f6818348b51ac9"
 
 export TESTNET="local"
 
-export DFX_VERSION="0.19.0"
+export DFX_VERSION="0.22.0"
 export DFX_SNS_VERSION="0.4.1"
 export DFX_NNS_VERSION="0.4.1"


### PR DESCRIPTION
When upgrading DFX from v0.19.0 to v0.22.0, there was a change in where DFX stores the registry info, so I added a new place for sns-testing to look for it in. I tried it on my mac and on CI and it seems to work.

I left the other places it looked in case any of them are used in some circumstances, but I don't think they are for this version of DFX. (Perhaps they would be useful if someone wanted to use an old version of DFX though.) The dfx start [docs](https://github.com/dfinity/sdk/blob/master/docs/cli-reference/dfx-start.mdx) say that:

> dfx stores data for the shared local network in one of the following locations, depending on your operating system:
> 
> $HOME/.local/share/dfx/network/local (Linux)
> $HOME/Library/Application Support/org.dfinity.dfx/network/local (Macos)

