### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/sns_lifecycle.yml
+++ b/.github/workflows/sns_lifecycle.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Build docker image
       run: |
         docker build -t ghcr.io/dfinity/sns-testing .
@@ -66,20 +66,20 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v4.6.0
+      uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
       with:
         images: ghcr.io/dfinity/sns-testing
     - name: Build and push Docker image
-      uses: docker/build-push-action@v4.1.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       with:
         context: .
         file: ./Dockerfile


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0`
  - Version: v2.7.0 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5

- `docker/login-action@v2` -> `docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0`
  - Version: v2.2.0 | Latest: v4.1.0 | Release age: 36d
  - Commit: https://github.com/docker/login-action/commit/465a07811f14bebb1938fbed4728c6a1ff8901fc
  - Warnings: Latest release v4.1.0 is only 6 day(s) old (< 7 days). Using previous safe release.

- `docker/metadata-action@v4.6.0` -> `docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0`
  - Version: v4.6.0 | Latest: v6.0.0 | Release age: 34d
  - Commit: https://github.com/docker/metadata-action/commit/818d4b7b91585d195f67373fd9cb0332e31a7175

- `docker/build-push-action@v4.1.1` -> `docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1`
  - Version: v4.1.1 | Latest: v7.0.0 | Release age: 34d
  - Commit: https://github.com/docker/build-push-action/commit/2eb1c1961a95fc15694676618e422e8ba1d63825


### Files modified

- `.github/workflows/sns_lifecycle.yml`

### Security warnings

- Latest release v4.1.0 is only 6 day(s) old (< 7 days). Using previous safe release.